### PR TITLE
Added support for randomized short url generation

### DIFF
--- a/core-services/egov-url-shortening/pom.xml
+++ b/core-services/egov-url-shortening/pom.xml
@@ -108,6 +108,12 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.hashids/hashids -->
+		<dependency>
+			<groupId>org.hashids</groupId>
+			<artifactId>hashids</artifactId>
+			<version>1.0.3</version>
+		</dependency>
 		
 	</dependencies>
 	<repositories>

--- a/core-services/egov-url-shortening/src/main/java/org/egov/url/shortening/utils/HashIdConverter.java
+++ b/core-services/egov-url-shortening/src/main/java/org/egov/url/shortening/utils/HashIdConverter.java
@@ -1,0 +1,36 @@
+package org.egov.url.shortening.utils;
+
+import org.hashids.Hashids;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+public class HashIdConverter {
+
+    @Value("${hashids.salt}")
+    private String salt;
+    @Value("${hsahids.min.length}")
+    private Integer minimumLength;
+
+    private Hashids hashids;
+
+    @PostConstruct
+    public void init() {
+        hashids = new Hashids(salt, minimumLength);
+    }
+
+    public String createHashStringForId(Long id) {
+        return hashids.encode(id);
+    }
+
+    public Long getIdForString(String string) {
+        long[] ids = hashids.decode(string);
+        if(ids.length == 1)
+            return ids[0];
+        return null;
+
+    }
+
+}

--- a/core-services/egov-url-shortening/src/main/resources/application.properties
+++ b/core-services/egov-url-shortening/src/main/resources/application.properties
@@ -26,3 +26,6 @@ spring.flyway.enabled=true
 db.persistance.enabled=true
 
 host.name=https://qa.digit.org/
+
+hashids.salt=randomsalt
+hsahids.min.length=3


### PR DESCRIPTION
This code generates a randomized ids (previously it generated sequential ids) so that it cannot be guessed by users. [Hashids](https://hashids.org/) is used for this purpose. Previously generated sequential ids will also return correct long url, hence it is also backward compatible. To make sure that the new urls do not conflict with the previously generated urls and backward compatibility is maintained, set the minimum length of the output url to be greater than highest length of the currently generated urls.