### PR TITLE
Meter bill aggregation fix

### DIFF
--- a/municipal-services/ws-calculator/src/main/java/org/egov/wscalculation/service/EstimationService.java
+++ b/municipal-services/ws-calculator/src/main/java/org/egov/wscalculation/service/EstimationService.java
@@ -170,10 +170,8 @@ public class EstimationService {
 				for (Slab slab : billSlab.getSlabs()) {
 					if (totalUOM > slab.getTo()) {
 						waterCharge = waterCharge.add(BigDecimal.valueOf(((slab.getTo()) - (slab.getFrom())) * slab.getCharge()));
-						totalUOM = totalUOM - ((slab.getTo()) - (slab.getFrom()));
-					} else if (totalUOM < slab.getTo()) {
-						waterCharge = waterCharge.add(BigDecimal.valueOf(totalUOM * slab.getCharge()));
-						totalUOM = ((slab.getTo()) - (slab.getFrom())) - totalUOM;
+					} else if (totalUOM <= slab.getTo()) {
+						waterCharge = waterCharge.add(BigDecimal.valueOf((totalUOM-slab.getFrom()) * slab.getCharge()));
 						break;
 					}
 				}


### PR DESCRIPTION
Existing calculation gives wrong result for configured parameter 
https://github.com/egovernments/egov-mdms-data/blob/1211f6ec37cf34da65dccde6f55807f20ad14913/data/pb/ws-services-calculation/WCBillingSlab.json#L12


For example : 
UOM      | Calculated Amount  | Expected Amount 
10                        Fail                        20                       ( will set 100 rs as min amount ) 
25                        57.5                       85
31                        133                         137
