### PR TITLE
Jurisdiction based workflow changes

### DIFF
--- a/municipal-services/property-services/src/main/java/org/egov/pt/models/hrms/Employee.java
+++ b/municipal-services/property-services/src/main/java/org/egov/pt/models/hrms/Employee.java
@@ -1,0 +1,52 @@
+package org.egov.pt.models.hrms;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.egov.pt.models.Locality;
+import org.egov.pt.models.user.User;
+
+import lombok.Data;
+
+@Data
+public class Employee {
+
+	  private Long id;
+
+	    private String uuid;
+
+	    private String code;
+
+	    private String employeeStatus;
+
+	    private String employeeType;
+
+	    private Long dateOfAppointment;
+
+	    private List<Locality> jurisdictions = new ArrayList<>();
+
+	    private List<Object> assignments = new ArrayList<>();
+
+	    private List<Object> serviceHistory = new ArrayList<>();
+
+
+	    private Boolean IsActive;
+
+	    private List<String> education = new ArrayList<>();
+
+	    private List<String> tests = new ArrayList<>();
+
+	    private String tenantId;
+
+	    private List<String> documents = new ArrayList<>();
+
+	    private List<String> deactivationDetails = new ArrayList<>();
+
+	    private List<String> reactivationDetails = new ArrayList<>();
+
+	    private Object auditDetails;
+
+	    private Boolean reActivateEmployee;
+	    
+	    private User user;
+}

--- a/municipal-services/property-services/src/main/java/org/egov/pt/models/hrms/HRMSResponse.java
+++ b/municipal-services/property-services/src/main/java/org/egov/pt/models/hrms/HRMSResponse.java
@@ -1,0 +1,13 @@
+package org.egov.pt.models.hrms;
+
+import java.util.List;
+
+import org.egov.common.contract.response.ResponseInfo;
+
+import lombok.Data;
+
+@Data
+public class HRMSResponse {
+    private ResponseInfo responseInfo;
+    private List<Employee> employees;
+}

--- a/municipal-services/property-services/src/main/java/org/egov/pt/service/HrmsService.java
+++ b/municipal-services/property-services/src/main/java/org/egov/pt/service/HrmsService.java
@@ -1,0 +1,72 @@
+package org.egov.pt.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+import org.egov.pt.models.hrms.HRMSResponse;
+import org.egov.pt.repository.ServiceRequestRepository;
+import org.egov.pt.web.contracts.RequestInfoWrapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Service
+public class HrmsService {
+
+	@Autowired
+	private ServiceRequestRepository serviceRequestRepository;
+
+	@Value("${egov.hrms.host}")
+	private String hrmsHost;
+
+	@Value("${egov.hrms.search.path}")
+	private String hrmsSearchEndpoint;
+	
+	@Autowired
+	ObjectMapper objectMapper;
+
+	/**
+	 * Performs an API call to the searchHRMS endpoint.
+	 *
+	 * @param requestInfo RequestInfo for the API call
+	 * @param tenantId    Tenant ID
+	 * @param roles       List of roles
+	 * @param boundary    Boundary parameter
+	 * @return Response from the HRMS searchHRMS endpoint
+	 */
+	public HRMSResponse searchHRMS(RequestInfo requestInfo, String tenantId, List<Role> roles, String boundary) {
+	
+		 List<String> roleCodes = roles.stream()
+		            .map(Role::getCode)
+		            .collect(Collectors.toList());
+		
+		 String rolesString = String.join(",", roleCodes);
+		// Create the API URL
+		String apiUrl = hrmsHost + hrmsSearchEndpoint + "?tenantId=" + tenantId + "&roles=" + rolesString + "&boundary="
+				+ boundary;
+
+		try {
+			
+			Optional<Object> response = serviceRequestRepository.fetchResult(new StringBuilder(apiUrl), RequestInfoWrapper.builder().requestInfo(requestInfo).build());
+			if (response.isPresent()) {
+				String responseString = objectMapper.writeValueAsString(response.get());
+
+	            // Parse the response and map it to HRMSResponse object
+	            HRMSResponse hrmsResponse = objectMapper.readValue(responseString, HRMSResponse.class);
+	            return hrmsResponse;
+	        } else {  
+	            return null; 
+	        }
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+}

--- a/municipal-services/property-services/src/main/java/org/egov/pt/util/PTConstants.java
+++ b/municipal-services/property-services/src/main/java/org/egov/pt/util/PTConstants.java
@@ -15,6 +15,8 @@ public class PTConstants {
     
     public static final String PT_TYPE_BUILTUP = "BUILTUP";
     
+    public static final String PT_ASSESSOR_TYPE_EMPLOYEE = "EMPLOYEE";
+    
     public static final String JSONPATH_CODES = "$.MdmsRes.PropertyTax";
 
     public static final String MDMS_PT_MOD_NAME = "PropertyTax";

--- a/municipal-services/property-services/src/main/java/org/egov/pt/validator/PropertyValidator.java
+++ b/municipal-services/property-services/src/main/java/org/egov/pt/validator/PropertyValidator.java
@@ -21,10 +21,13 @@ import org.egov.pt.models.PropertyCriteria;
 import org.egov.pt.models.Unit;
 import org.egov.pt.models.enums.CreationReason;
 import org.egov.pt.models.enums.Status;
+import org.egov.pt.models.hrms.Employee;
+import org.egov.pt.models.hrms.HRMSResponse;
 import org.egov.pt.models.workflow.BusinessService;
 import org.egov.pt.models.workflow.ProcessInstance;
 import org.egov.pt.models.workflow.State;
 import org.egov.pt.service.DiffService;
+import org.egov.pt.service.HrmsService;
 import org.egov.pt.service.PropertyService;
 import org.egov.pt.service.WorkflowService;
 import org.egov.pt.util.EncryptionDecryptionUtil;
@@ -33,6 +36,7 @@ import org.egov.pt.util.PropertyUtil;
 import org.egov.pt.web.contracts.PropertyRequest;
 import org.egov.tracer.model.CustomException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
@@ -67,6 +71,12 @@ public class PropertyValidator {
     
     @Autowired
     private WorkflowService workflowService;
+    
+    @Value("${egov.jurisdiction.enable}")
+    private Boolean isJurisdictionEnabled;
+
+    @Autowired
+    private HrmsService hrmsService;
 
 	@Autowired
 	EncryptionDecryptionUtil encryptionDecryptionUtil;
@@ -232,6 +242,11 @@ public class PropertyValidator {
 		Property property = request.getProperty();
 		validateIds(request, errorMap);
 		validateMobileNumber(request, errorMap);
+		
+		if(isJurisdictionEnabled) {
+    		validateJurisdictionMatchWithAssesor(request, errorMap);
+    		validateJurisdictionMatchwithAssignedTo(request,errorMap);
+    	}
 
 
 		CreationReason reason = property.getCreationReason();
@@ -254,6 +269,83 @@ public class PropertyValidator {
 
 		if (!errorMap.isEmpty())
 			throw new CustomException(errorMap);
+	}
+	
+	// to validate if the assignees is in the same jurisdiction as the property
+	private void validateJurisdictionMatchwithAssignedTo(PropertyRequest request, Map<String, String> errorMap) {
+
+		List<OwnerInfo> assignes = request.getProperty().getWorkflow().getAssignes();
+		HRMSResponse employeeResponse = hrmsService.searchHRMS(request.getRequestInfo(),
+				request.getProperty().getTenantId(), request.getRequestInfo().getUserInfo().getRoles(),
+				request.getProperty().getAddress().getLocality().getCode());
+		List<OwnerInfo> filteredAssignes = new ArrayList<OwnerInfo>();
+
+		if (employeeResponse != null) {
+			List<Employee> employees = employeeResponse.getEmployees();
+			filteredAssignes = assignes.stream().filter(assigne -> employees.stream().anyMatch(
+					employee -> employee.getUser() != null && employee.getUser().getUuid().equals(assigne.getUuid())))
+					.collect(Collectors.toList());
+
+			if (filteredAssignes.isEmpty()) {
+				if (!employees.isEmpty()) {
+					Employee firstEmployee = employees.get(0);
+					org.egov.pt.models.user.User user = firstEmployee.getUser();
+
+					// Set the uuid and name of correct employee to the assigne object
+					if (assignes.isEmpty()) {
+						OwnerInfo newOwner = new OwnerInfo();
+						newOwner.setUuid(user.getUuid());
+						newOwner.setName(user.getName());
+						assignes.add(newOwner);
+					} else {
+						assignes.forEach(assigne -> {
+							assigne.setUuid(user.getUuid());
+							assigne.setName(user.getName());
+						});
+					}
+					log.info(
+							"The assignee has been changed to one mapped in the system as the one selected wasn't correct.");
+					request.getProperty().getWorkflow().setAssignes(assignes);
+				} else {
+					errorMap.put("EG_PT_UPDATE AUTHORIZATION FAILURE",
+							"Not Authorized to update property with propertyId as the assignees are not present in the jurisdiction of the property "
+									+ request.getProperty().getPropertyId());
+				}
+			}
+		}
+
+		if (!errorMap.isEmpty())
+			throw new CustomException(errorMap);
+
+	}
+
+	// To validate the assessor is in the same jurisdiction as the property
+	private void validateJurisdictionMatchWithAssesor(PropertyRequest request, Map<String, String> errorMap) {
+
+		HRMSResponse employeeResponse = hrmsService.searchHRMS(request.getRequestInfo(),
+				request.getProperty().getTenantId(), request.getRequestInfo().getUserInfo().getRoles(),
+				request.getProperty().getAddress().getLocality().getCode());
+		if (employeeResponse == null) {
+
+			errorMap.put("EG_PT_UPDATE AUTHORIZATION FAILURE",
+					"Not Authorized to update property with propertyId due to no employee in this Jurisdiction "
+							+ request.getProperty().getPropertyId());
+		}
+
+		String userUUID = request.getRequestInfo().getUserInfo().getUuid();
+		List<String> employeeUuids = new ArrayList<String>();
+		if (employeeResponse != null) {
+			employeeUuids = employeeResponse.getEmployees().stream().map(Employee::getUuid)
+					.collect(Collectors.toList());
+		}
+		if (!employeeUuids.contains(userUUID)) {
+			errorMap.put("EG_PT_UPDATE AUTHORIZATION FAILURE",
+					"Not Authorized to update property with propertyId due to employee record not found in this Jurisdiction "
+							+ request.getProperty().getPropertyId());
+		}
+		if (!errorMap.isEmpty())
+			throw new CustomException(errorMap);
+
 	}
 
     /**

--- a/municipal-services/property-services/src/main/resources/application.properties
+++ b/municipal-services/property-services/src/main/resources/application.properties
@@ -131,6 +131,12 @@ egov.localization.search.endpoint=/_search
 egov.localization.statelevel=true
 egov.localization.fallback.locale=en_IN
 
+#jurisdiction level flag
+egov.jurisdiction.enable=false
+
+#hrms-service
+egov.hrms.host=http://127.0.0.1:9999
+egov.hrms.search.path=/egov-hrms/employees/_search
 
 #mdms urls
 egov.mdms.host=https://dev.digit.org

--- a/municipal-services/property-services/src/main/resources/application.properties
+++ b/municipal-services/property-services/src/main/resources/application.properties
@@ -131,8 +131,8 @@ egov.localization.search.endpoint=/_search
 egov.localization.statelevel=true
 egov.localization.fallback.locale=en_IN
 
-#jurisdiction level flag
-egov.jurisdiction.enable=false
+#jurisdiction level flag to enable jurisdiction level validation
+egov.jurisdiction.enable=true
 
 #hrms-service
 egov.hrms.host=http://127.0.0.1:9999


### PR DESCRIPTION
Issue 71 - Jurisdiction based changes 

Made the following changes to check if the assessor/assignee is in the jurisdiction of the property

-> Added HrmsService to fetch employee data in a particular jurisdiction
-> Added appropriate data models - Employee and HRMSResponse to store the fetched response
-> Modified PropertyValidator to validate based on juridiction at 2 levels while updating property. First for the assessor to be in the same jurisdiction and the assignee to be in the same jurisdiction as well
-> Modified application.properties for jurisdiction flag and hrms endpoint