### PR TITLE
[Feat]: decoupled tenant service from mdms service to interface

### DIFF
--- a/core-services/egov-enc-service/Dockerfile
+++ b/core-services/egov-enc-service/Dockerfile
@@ -1,0 +1,4 @@
+FROM frolvlad/alpine-java:jdk8-slim
+WORKDIR /app
+ADD ./target/egov-enc-service-1.1.4.jar enc-service.jar
+ENTRYPOINT ["java", "-jar", "enc-service.jar"]

--- a/core-services/egov-enc-service/README.md
+++ b/core-services/egov-enc-service/README.md
@@ -8,6 +8,7 @@ Encryption Service is used to secure the data. It provides functionality to encr
 
 ### Service Dependencies
 
+If using TenantService as MDMSTenantService (default)
 - egov-mdms-service
 
 

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/models/Tenant.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/models/Tenant.java
@@ -1,0 +1,19 @@
+package org.egov.enc.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class Tenant {
+
+    private int id;
+
+    private String tenantId;
+
+}
+

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/repository/DBTenantRepository.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/repository/DBTenantRepository.java
@@ -1,0 +1,28 @@
+package org.egov.enc.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import org.egov.enc.models.Tenant;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Slf4j
+@ConditionalOnProperty(name = "tenant.service", havingValue = "DBTenantService")
+@Repository
+public class DBTenantRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final String selectTenantsQuery = "SELECT * FROM eg_tenants";
+    @Autowired
+    public DBTenantRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<Tenant> fetchTenants() {
+        return jdbcTemplate.query(selectTenantsQuery, new BeanPropertyRowMapper<>(Tenant.class));
+    }
+}

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/services/DBTenantService.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/services/DBTenantService.java
@@ -1,0 +1,27 @@
+package org.egov.enc.services;
+
+import org.egov.enc.models.Tenant;
+import org.egov.enc.repository.DBTenantRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ConditionalOnProperty(name = "tenant.service", havingValue = "DBTenantService")
+@Service
+public class DBTenantService implements TenantService {
+    private final DBTenantRepository dbTenantRepository;
+
+    public DBTenantService(DBTenantRepository dbTenantRepository) {
+        this.dbTenantRepository = dbTenantRepository;
+
+    }
+
+    @Override
+    public List<String> getTenantIds() {
+        return dbTenantRepository.fetchTenants()
+                .stream().map(Tenant::getTenantId)
+                .collect(Collectors.toList());
+    }
+}

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/services/MDMSTenantService.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/services/MDMSTenantService.java
@@ -1,0 +1,54 @@
+package org.egov.enc.services;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+@ConditionalOnProperty(name = "tenant.service", havingValue = "MDMSTenantService", matchIfMissing = true)
+@Service
+public class MDMSTenantService implements TenantService {
+    @Value("${egov.mdms.host}")
+    private String mdmsHost;
+
+    @Value("${egov.mdms.search.endpoint}")
+    private String mdmsEndpoint;
+
+    @Value(("${egov.state.level.tenant.id}"))
+    private String stateLevelTenantId;
+    @Override
+    public List<String> getTenantIds() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        String requestJson = "{\"RequestInfo\":{},\"MdmsCriteria\":{\"tenantId\":\"" + stateLevelTenantId + "\"," +
+                "\"moduleDetails\":[{\"moduleName\":\"tenant\",\"masterDetails\":[{\"name\":\"tenants\"," +
+                "\"filter\":\"$.*.code\"}]}]}}";
+
+        String url = mdmsHost + mdmsEndpoint;
+
+        HttpEntity<String> entity = new HttpEntity<>(requestJson, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
+
+        JSONObject jsonObject = new JSONObject(response.getBody());
+        JSONArray jsonArray = jsonObject.getJSONObject("MdmsRes").getJSONObject("tenant").getJSONArray("tenants");
+
+        List<String> tenantIds = new ArrayList<>();
+        for(int i = 0; i < jsonArray.length(); i++) {
+            tenantIds.add(jsonArray.getString(i));
+        }
+
+        return tenantIds;
+    }
+}

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/services/TenantService.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/services/TenantService.java
@@ -1,0 +1,7 @@
+package org.egov.enc.services;
+
+import java.util.List;
+
+public interface TenantService {
+    List<String> getTenantIds();
+}

--- a/core-services/egov-enc-service/src/main/resources/application.properties
+++ b/core-services/egov-enc-service/src/main/resources/application.properties
@@ -54,3 +54,6 @@ egov.state.level.tenant.id=pb
 
 #---------Master Password provider ; Currently supported - software, awskms--------#
 master.password.provider=software
+
+#----------Tenant Service: MDMSTenantService or DBTenantService------------#
+tenant.service=MDMSTenantService

--- a/core-services/egov-enc-service/src/main/resources/db/migration/main/V20230928185601__eg_tenants.sql
+++ b/core-services/egov-enc-service/src/main/resources/db/migration/main/V20230928185601__eg_tenants.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS  eg_tenants;
+
+CREATE TABLE public."eg_tenants"
+(
+    id SERIAL,
+    tenant_id text NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX eg_tenant_id ON eg_tenants (tenant_id);
+INSERT INTO eg_tenants (tenant_id) VALUES ('default');


### PR DESCRIPTION
Changes done: 

1. Extracted out using tenants from mdms to interface `TenantService`
2. Created `MDMSTenantService` to using mdms on configuration basis
3. Created `DBTenantService` to use tenants from database which create a tenant _`default`_
4. Added application property `tenant.service` for selection between _MDMSTenantService_ and _DBTenantService_